### PR TITLE
feature: mine sentences

### DIFF
--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -25,5 +25,7 @@ auto_open = true
 ### and removes it from all decks which are marked as known
 # auto_forget = true
 
+# add_mined_sentences = true
+
 ### for debugging and development purposes
 # log_level = "Trace"

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,8 @@ pub struct Config {
     #[serde(default)]
     pub auto_forget: bool,
     pub log_level: Option<Level>,
+    #[serde(default)]
+    pub add_mined_sentences: bool,
 }
 
 pub struct Cache {
@@ -62,12 +64,14 @@ async fn validate_config(config: &Config, client: &reqwest::Client) -> Result<()
     info!("Auto FORQ: {}", config.auto_forq);
     info!("Auto unlock: {}", config.auto_unlock);
     info!("Auto forget: {}", config.auto_forget);
+    info!("Add mined sentences: {}", config.add_mined_sentences);
 
     if !config.auto_open
         && !should_auto_add
         && !config.auto_forq
         && !config.auto_unlock
         && !config.auto_forget
+        && !config.add_mined_sentences
     {
         warn!("In this configuration jpdb-connect does not do anything.");
     }
@@ -76,7 +80,8 @@ async fn validate_config(config: &Config, client: &reqwest::Client) -> Result<()
         && (config.auto_add.is_some()
             || config.auto_forq
             || config.auto_unlock
-            || config.auto_forget);
+            || config.auto_forget
+            || config.add_mined_sentences);
     if test_login {
         let response = client
             .get(if let Some(deck_id) = config.auto_add {


### PR DESCRIPTION
add the sentence from yomichan to the custom sentence field

bug: probably still fails if jpdb doesn't think the sentence contains the word. have to implement a hack for this (add the spelling jpdb wants at the end in parens, optionally only if the sentence alone can't be added successfully) until we get around to the "correct" solution involving using jpdb's parser to pick the spelling and so on. this can also be worked around from within yomichan itself, by setting the value of the `sentence` field to `{sentence} ({expression})`