### PR TITLE
Suppress the error from unsupported anki-connect storeMediaFile method

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -276,6 +276,10 @@ async fn handle_action(
             //format!(r#"[{}]"#, v)
             Response::error("duplicate detection")
         }
+        "storeMediaFile" => {
+            warn!("unsupported action {}", action.action);
+            Response::result("_hello.txt")
+        }
         _ => {
             // multi
             // findnotes


### PR DESCRIPTION
Using the latest release of yomitan generates an AnkiConnect method `storeMediaFile`. Returning an error would cause annoying error messages to be emitted in the extension UI, even though the vocab is successfully mined to jpdb. This pretends that the operation completed successfully even though no media is uploaded to jpdb.